### PR TITLE
Generate standard JWT signature instead of ASN.1

### DIFF
--- a/Sources/ECPrivateKey.swift
+++ b/Sources/ECPrivateKey.swift
@@ -34,6 +34,8 @@ extension ECPrivateKey {
             throw error!.takeRetainedValue()
         }
 
-        return (signature as Data).base64EncodedURLString()
+        let rawSignature = try (signature as ASN1).toRawSignature()
+
+        return rawSignature.base64EncodedURLString()
     }
 }


### PR DESCRIPTION
SecKeyCreateSignature generates a signature in ASN.1 format, whereas
the JWT RFC says the signature should be two raw 32byte integers one
after the other.

Decode the ASN.1 and extract the two raw integers to use as the raw
signature. The only slight difficultly is that 32byte integers are
way larger than swift can deal with so we need to get the parser to
return them as the raw Data object instead of an Int.

With this change, the signatures generated by CupertinoJWT can be
verified using jwt.io. To verify you'll need to get the public key,
which can be generated from the Apple P8 using:

openssl ec -in private-key.pem -pubout -out pubkey.pem

closes #6