### PR TITLE
Refactors JWT struct to support additional Apple services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ do {
         }
     }
     
-    let apnsHeader = APNsHeader(keyID: "JMR5QXHU8X")
+    let apnsHeader = APNsHeader(keyID: keyID)
     let issueDate = Date()
     let iat = Int(issueDate.timeIntervalSince1970.rounded())
     let expireDuration = 20 * 60
     let exp = iat + Int(expireDuration)
-    let apnsPayload = APNsPayload(teamID: "69a6de93-630a-47e3-e053-5b8c7c11a4d1", issueDate: iat, expireDate: exp)
+    let apnsPayload = APNsPayload(teamID: teamID, issueDate: iat, expireDate: exp)
     let jwt = JsonWebToken<APNsHeader, APNsPayload>(header: apnsHeader, payload: apnsPayload)
     
     let jsonEncoder = JSONEncoder()
@@ -247,12 +247,12 @@ do {
         }
     }
     
-    let ascHeader = AppStoreConnectHeader(keyID: "JMR5QXHU8X")
+    let ascHeader = AppStoreConnectHeader(keyID: keyID)
     let issueDate = Date()
     let iat = Int(issueDate.timeIntervalSince1970.rounded())
     let expireDuration = 20 * 60
     let exp = iat + Int(expireDuration)
-    let ascPayload = AppStoreConnectPayload(teamID: "69a6de93-630a-47e3-e053-5b8c7c11a4d1", expireDate: exp)
+    let ascPayload = AppStoreConnectPayload(teamID: teamID, expireDate: exp)
     let jwt = JsonWebToken<AppStoreConnectHeader, AppStoreConnectPayload>(header: ascHeader, payload: ascPayload)
     
     let jsonEncoder = JSONEncoder()

--- a/Sources/JWT.swift
+++ b/Sources/JWT.swift
@@ -8,68 +8,89 @@
 
 import Foundation
 
-public struct JWT: Codable {
-    private struct Header: Codable {
-        /// alg
-        let algorithm: String = "ES256"
-
-        /// kid
-        let keyID: String
-
-        enum CodingKeys: String, CodingKey {
-            case algorithm = "alg"
-            case keyID = "kid"
-        }
+/// Generalized form of a JWT.
+public struct JsonWebToken<H: Codable, P: Codable>: Codable {
+    private let header: H
+    private let payload: P
+    
+    public init(header: H, payload: P) {
+        self.header = header
+        self.payload = payload
     }
-
-    private struct Payload: Codable {
-        /// iss
-        public let teamID: String
-
-        /// iat
-        public let issueDate: Int
-
-        /// exp
-        public let expireDate: Int
-
-        enum CodingKeys: String, CodingKey {
-            case teamID = "iss"
-            case issueDate = "iat"
-            case expireDate = "exp"
-        }
-    }
-
-    private let header: Header
-
-    private let payload: Payload
-
-    public init(keyID: String, teamID: String, issueDate: Date, expireDuration: TimeInterval) {
-
-        header = Header(keyID: keyID)
-
-        let iat = Int(issueDate.timeIntervalSince1970.rounded())
-        let exp = iat + Int(expireDuration)
-
-        payload = Payload(teamID: teamID, issueDate: iat, expireDate: exp)
-    }
-
+    
     /// Combine header and payload as digest for signing.
     public func digest() throws -> String {
         let headerString = try JSONEncoder().encode(header.self).base64EncodedURLString()
         let payloadString = try JSONEncoder().encode(payload.self).base64EncodedURLString()
         return "\(headerString).\(payloadString)"
     }
-
+    
     /// Sign digest with P8(PEM) string. Use the result in your request authorization header.
     public func sign(with p8: P8) throws -> String {
         let digest = try self.digest()
-
+        
         let signature = try p8.toASN1()
             .toECKeyData()
             .toPrivateKey()
             .es256Sign(digest: digest)
-
+        
         let token = "\(digest).\(signature)"
         return token
+    }
+}
+
+// One possible way to compose a specific header and payload structure
+// into a JWT. In this case, it is for APNs.
+public struct JWT: Codable {
+    private struct APNsHeader: Codable {
+        /// alg
+        let algorithm: String = "ES256"
+        
+        /// kid
+        let keyID: String
+        
+        enum CodingKeys: String, CodingKey {
+            case algorithm = "alg"
+            case keyID = "kid"
+        }
+    }
+    
+    private struct APNsPayload: Codable {
+        /// iss
+        public let teamID: String
+        
+        /// iat
+        public let issueDate: Int
+        
+        /// exp
+        public let expireDate: Int
+        
+        enum CodingKeys: String, CodingKey {
+            case teamID = "iss"
+            case issueDate = "iat"
+            case expireDate = "exp"
+        }
+    }
+    
+    private let jwt: JsonWebToken<APNsHeader, APNsPayload>
+    
+    public init(keyID: String, teamID: String, issueDate: Date, expireDuration: TimeInterval) {
+        
+        let header = APNsHeader(keyID: keyID)
+        
+        let iat = Int(issueDate.timeIntervalSince1970.rounded())
+        let exp = iat + Int(expireDuration)
+        
+        let payload = APNsPayload(teamID: teamID, issueDate: iat, expireDate: exp)
+        
+        jwt = JsonWebToken<APNsHeader, APNsPayload>(header: header, payload: payload)
+    }
+    
+    public func digest() throws -> String {
+        return try jwt.digest()
+    }
+    
+    public func sign(with p8: P8) throws -> String {
+        return try jwt.sign(with: p8)
     }
 }


### PR DESCRIPTION
Refactors the JWT struct into a generic called JsonWebToken and a wrapper called JWT (in order to maintain code compatibility with existing clients).

Provides two alternative usage samples in the Readme file, demonstrating how a client can construct an APNs or App Store Connect JWT.  This approach lends itself to supporting the specific needs of additional Apple server services.